### PR TITLE
remove default value for hostid parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           python-version: ${{ matrix.python-version }}
-          mamba-version: "*"
+          miniforge-variant: Mambaforge
           channels: conda-forge,defaults
           channel-priority: true
           activate-environment: fsspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         runs-on: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         runs-on: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
+          python-version: ${{ matrix.python-version }}
           mamba-version: "*"
           channels: conda-forge,defaults
           channel-priority: true
@@ -54,7 +55,7 @@ jobs:
       - name: Install build environment
         shell: bash -l {0}
         run: |
-          mamba install -c conda-forge python=${{ matrix.python-version }} "xrootd>=5.4.3"
+          mamba install -c conda-forge "xrootd>=5.4.3"
       - name: Install package
         shell: bash -l {0}
         run: python -m pip install .[test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.10"]
         runs-on: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v2.1.1
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           mamba-version: "*"
           channels: conda-forge,defaults

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         additional_dependencies: [black==22.3.0]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["-a", "from __future__ import annotations"] # Python 3.7+
@@ -84,7 +84,7 @@ repos:
         additional_dependencies: *flake8_dependencies
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.961
+    rev: v1.4.1
     hooks:
       - id: mypy
         files: src

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,6 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
     Topic :: Scientific/Engineering
 project_urls =
     Documentation = https://fsspec_xrootd.readthedocs.io/

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,8 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Scientific/Engineering
 project_urls =
     Documentation = https://fsspec_xrootd.readthedocs.io/

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -197,9 +197,9 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
     def _strip_protocol(cls, path: str | list[str]) -> Any:
         if type(path) == str:
             if path.startswith(cls.protocol):
-                return client.URL(path).path or cls.root_marker
+                return client.URL(path).path.rstrip("/") or cls.root_marker
             # assume already stripped
-            return path
+            return path.rstrip("/") or cls.root_marker
         elif type(path) == list:
             return [cls._strip_protocol(item) for item in path]
         else:

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -174,7 +174,7 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
         self.timeout = storage_options.get("timeout", XRootDFileSystem.default_timeout)
         self._myclient = client.FileSystem("root://" + hostid)
         if not self._myclient.url.is_valid():
-            raise ValueError(f"Invalid hostid: '{hostid}'")
+            raise ValueError(f"Invalid hostid: {hostid!r}")
         storage_options.setdefault("listing_expiry_time", 0)
         self.storage_options = storage_options
 
@@ -676,6 +676,7 @@ class XRootDFile(AbstractBufferedFile):  # type: ignore[misc]
                 " deprecated. "
                 "Specify it within the 'cache_options' argument instead.",
                 FutureWarning,
+                stacklevel=1,
             )
             cache_options["trim"] = kwargs.pop("trim")
 

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -196,7 +196,10 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
     @classmethod
     def _strip_protocol(cls, path: str | list[str]) -> Any:
         if type(path) == str:
-            return client.URL(path).path or cls.root_marker
+            if path.startswith(cls.protocol):
+                return client.URL(path).path or cls.root_marker
+            # assume already stripped
+            return path
         elif type(path) == list:
             return [cls._strip_protocol(item) for item in path]
         else:

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -152,7 +152,7 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
 
     def __init__(
         self,
-        hostid: str = "",
+        hostid: str,
         asynchronous: bool = False,
         loop: Any = None,
         **storage_options: Any,

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -9,7 +9,11 @@ import time
 import fsspec
 import pytest
 
-from fsspec_xrootd.xrootd import XRootDFileSystem, _chunks_to_vectors, _vectors_to_chunks
+from fsspec_xrootd.xrootd import (
+    XRootDFileSystem,
+    _chunks_to_vectors,
+    _vectors_to_chunks,
+)
 
 TESTDATA1 = "apple\nbanana\norange\ngrape"
 TESTDATA2 = "red\ngreen\nyellow\nblue"
@@ -61,7 +65,7 @@ def test_invalid_parameters():
 def test_async_impl():
     cls = fsspec.get_filesystem_class(protocol="root")
     assert cls == XRootDFileSystem
-    assert cls.async_impl == True, "XRootDFileSystem should have async_impl=True"
+    assert cls.async_impl, "XRootDFileSystem should have async_impl=True"
 
 
 def test_broken_server():

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -53,6 +53,11 @@ def test_invalid_server():
         fsspec.core.url_to_fs("root://")
 
 
+def test_invalid_parameters():
+    with pytest.raises(TypeError):
+        fsspec.filesystem(protocol="root")
+
+
 def test_broken_server():
     with pytest.raises(OSError):
         # try to connect on the wrong port should fail

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -86,9 +86,14 @@ def test_path_parsing():
     fs, _, (path,) = fsspec.get_fs_token_paths("root://server.com//blah")
     assert path == "/blah"
     fs, _, paths = fsspec.get_fs_token_paths(
-        ["root://server.com//blah", "root://server.com//more"]
+        [
+            "root://server.com//blah",
+            "root://server.com//more",
+            "root://server.com/dir/",
+            "root://serv.er//dir/",
+        ]
     )
-    assert paths == ["/blah", "/more"]
+    assert paths == ["/blah", "/more", "dir", "/dir"]
 
 
 def test_pickle(localserver, clear_server):

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -9,7 +9,7 @@ import time
 import fsspec
 import pytest
 
-from fsspec_xrootd.xrootd import _chunks_to_vectors, _vectors_to_chunks
+from fsspec_xrootd.xrootd import XRootDFileSystem, _chunks_to_vectors, _vectors_to_chunks
 
 TESTDATA1 = "apple\nbanana\norange\ngrape"
 TESTDATA2 = "red\ngreen\nyellow\nblue"
@@ -56,6 +56,12 @@ def test_invalid_server():
 def test_invalid_parameters():
     with pytest.raises(TypeError):
         fsspec.filesystem(protocol="root")
+
+
+def test_async_impl():
+    cls = fsspec.get_filesystem_class(protocol="root")
+    assert cls == XRootDFileSystem
+    assert cls.async_impl == True, "XRootDFileSystem should have async_impl=True"
 
 
 def test_broken_server():


### PR DESCRIPTION
When playing around with `fsspec` I noticed that when you do not use the required arguments for the given filesystem (e.g. `host` for `protocol="ftp"`) it throws a `TypeError` pointing you to the argument you are missing.

```
>>> import fsspec
>>> fsspec.filesystem(protocol="ftp")
Exception ignored in: <function FTPFileSystem.__del__ at 0x102251d00>
Traceback (most recent call last):
  File "/Users/lobis/miniconda3/envs/uproot-311/lib/python3.11/site-packages/fsspec/implementations/ftp.py", line 248, in __del__
    self.ftp.close()
    ^^^^^^^^
AttributeError: 'FTPFileSystem' object has no attribute 'ftp'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/lobis/miniconda3/envs/uproot-311/lib/python3.11/site-packages/fsspec/registry.py", line 289, in filesystem
    return cls(**storage_options)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/lobis/miniconda3/envs/uproot-311/lib/python3.11/site-packages/fsspec/spec.py", line 79, in __call__
    obj = super().__call__(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: FTPFileSystem.__init__() missing 1 required positional argument: 'host'
```

This PR removes the default value for the `hostid` parameter. With the default value of `""` the instantiation was also giving an error but it was less descriptive and not in line with the other `fsspec` filesystems.

I also added a test to check the correct type of exception is thrown.

Behaviour after change:
```
>>> fsspec.filesystem(protocol="root")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/lobis/miniconda3/envs/uproot-311/lib/python3.11/site-packages/fsspec/registry.py", line 289, in filesystem
    return cls(**storage_options)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/lobis/miniconda3/envs/uproot-311/lib/python3.11/site-packages/fsspec/spec.py", line 79, in __call__
    obj = super().__call__(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: XRootDFileSystem.__init__() missing 1 required positional argument: 'hostid'
```