### PR TITLE
feat: support `simplecache` url chaining

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: python -m pip install .[test]
       - name: Test package
         run: |
-          python -m pytest -vv tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)OSError|timeout|expired|connection|socket"
+          python -m pytest -vv tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)OSError|FileNotFoundError|timeout|expired|connection|socket"
 
       - name: Run fsspec-xrootd tests from uproot latest release
         run: |
@@ -75,7 +75,7 @@ jobs:
           python -m pip install ./uproot[test]
           # Install xrootd-fsspec again because it may have been overwritten by uproot
           python -m pip install .[test]
-          python -m pytest -vv -k "xrootd" uproot/tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)OSError|timeout|expired|connection|socket"
+          python -m pytest -vv -k "xrootd" uproot/tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)OSError|FileNotFoundError|timeout|expired|connection|socket"
 
   dist:
     name: Distribution build

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -412,18 +412,18 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
                 self.timeout,
             )
 
-    async def _get_file(self, rpath: str, lpath: str, **kwargs: Any) -> None:
+    async def _get_file(
+        self, rpath: str, lpath: str, chunk_size: int = 8192, **kwargs: Any
+    ) -> None:
         # Open the remote file for reading
         file = await self.open_async(rpath, mode="rb")
-
         try:
-            # Read the content of the remote file
-            content = await file.read()
-
-            # Write the content to the local file
             with open(lpath, "wb") as local_file:
-                local_file.write(content)
-
+                while True:
+                    chunk = await file.read(chunk_size)
+                    if not chunk:
+                        break
+                    local_file.write(chunk)
         finally:
             # Close the remote file
             await file.close()

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -413,7 +413,7 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
             )
 
     async def _get_file(
-        self, rpath: str, lpath: str, chunk_size: int = 8192, **kwargs: Any
+        self, rpath: str, lpath: str, chunk_size: int = 262_144, **kwargs: Any
     ) -> None:
         # Open the remote file for reading
         remote_file = client.File()

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -259,7 +259,7 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
 
     rmdir = sync_wrapper(_rmdir)
 
-    async def _rm_file(self, path: str) -> None:
+    async def _rm_file(self, path: str, **kwargs: Any) -> None:
         status, n = await _async_wrap(self._myclient.rm, path, self.timeout)
         if not status.ok:
             raise OSError(f"File not removed properly: {status.message}")

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -412,6 +412,22 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
                 self.timeout,
             )
 
+    async def _get_file(self, rpath: str, lpath: str, **kwargs: Any) -> None:
+        # Open the remote file for reading
+        file = await self.open_async(rpath, mode="rb")
+
+        try:
+            # Read the content of the remote file
+            content = await file.read()
+
+            # Write the content to the local file
+            with open(lpath, "wb") as local_file:
+                local_file.write(content)
+
+        finally:
+            # Close the remote file
+            await file.close()
+
     async def _get_max_chunk_info(self, file: Any) -> tuple[int, int]:
         """Queries the XRootD server for info required for pyxrootd vector_read() function.
         Queries for maximum number of chunks and the maximum chunk size allowed by the server.

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -391,7 +391,7 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
         try:
             status, _n = await _async_wrap(
                 _myFile.open,
-                self.protocol + "://" + self.storage_options["hostid"] + "/" + path,
+                self.unstrip_protocol(path),
                 OpenFlags.READ,
                 self.timeout,
             )
@@ -421,7 +421,7 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
         try:
             status, _n = await _async_wrap(
                 remote_file.open,
-                self.protocol + "://" + self.storage_options["hostid"] + "/" + rpath,
+                self.unstrip_protocol(rpath),
                 OpenFlags.READ,
                 self.timeout,
             )
@@ -449,9 +449,7 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
 
         finally:
             # Close the remote file
-            status, _n = await _async_wrap(remote_file.close, self.timeout)
-
-        return None
+            await _async_wrap(remote_file.close, self.timeout)
 
     async def _get_max_chunk_info(self, file: Any) -> tuple[int, int]:
         """Queries the XRootD server for info required for pyxrootd vector_read() function.

--- a/src/fsspec_xrootd/xrootd.py
+++ b/src/fsspec_xrootd/xrootd.py
@@ -433,7 +433,7 @@ class XRootDFileSystem(AsyncFileSystem):  # type: ignore[misc]
                 while True:
                     # Read a chunk of content from the remote file
                     status, chunk = await _async_wrap(
-                        remote_file.read, start, start + chunk_size, self.timeout
+                        remote_file.read, start, chunk_size, self.timeout
                     )
                     start += chunk_size
 

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -414,10 +414,12 @@ def test_glob_full_names(localserver, clear_server):
             assert f.read() in [bytes(data, "utf-8") for data in [TESTDATA1, TESTDATA2]]
 
 
-def test_cache(localserver, clear_server):
+@pytest.mark.parametrize("protocol_prefix", ["", "simplecache::"])
+def test_cache(localserver, clear_server, protocol_prefix):
     remoteurl, localpath = localserver
     with open(localpath + "/testfile.txt", "w") as fout:
         fout.write(TESTDATA1)
 
-    with fsspec.open("simplecache::" + remoteurl + "/testfile.txt", "rb") as f:
-        assert f.readuntil(b"e") == b"apple"
+    with fsspec.open(protocol_prefix + remoteurl + "/testfile.txt", "rb") as f:
+        contents = f.read()
+        assert contents == TESTDATA1.encode("utf-8")

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -412,3 +412,12 @@ def test_glob_full_names(localserver, clear_server):
     for name in full_names:
         with fsspec.open(name) as f:
             assert f.read() in [bytes(data, "utf-8") for data in [TESTDATA1, TESTDATA2]]
+
+
+def test_cache(localserver, clear_server):
+    remoteurl, localpath = localserver
+    with open(localpath + "/testfile.txt", "w") as fout:
+        fout.write(TESTDATA1)
+
+    with fsspec.open("simplecache::" + remoteurl + "/testfile.txt", "rb") as f:
+        assert f.readuntil(b"e") == b"apple"

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -416,7 +416,7 @@ def test_glob_full_names(localserver, clear_server):
 
 @pytest.mark.parametrize("protocol_prefix", ["", "simplecache::"])
 def test_cache(localserver, clear_server, protocol_prefix):
-    data = TESTDATA1 * 2000  # bigger than the chunk size
+    data = TESTDATA1 * int(1e7 / len(TESTDATA1))  # bigger than the chunk size
     remoteurl, localpath = localserver
     with open(localpath + "/testfile.txt", "w") as fout:
         fout.write(data)

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -416,13 +416,14 @@ def test_glob_full_names(localserver, clear_server):
 
 @pytest.mark.parametrize("protocol_prefix", ["", "simplecache::"])
 def test_cache(localserver, clear_server, protocol_prefix):
+    data = TESTDATA1 * 2000  # bigger than the chunk size
     remoteurl, localpath = localserver
     with open(localpath + "/testfile.txt", "w") as fout:
-        fout.write(TESTDATA1)
+        fout.write(data)
 
     with fsspec.open(protocol_prefix + remoteurl + "/testfile.txt", "rb") as f:
         contents = f.read()
-        assert contents == TESTDATA1.encode("utf-8")
+        assert contents == data.encode("utf-8")
 
 
 def test_cache_directory(localserver, clear_server, tmp_path):

--- a/tests/test_basicio.py
+++ b/tests/test_basicio.py
@@ -423,3 +423,23 @@ def test_cache(localserver, clear_server, protocol_prefix):
     with fsspec.open(protocol_prefix + remoteurl + "/testfile.txt", "rb") as f:
         contents = f.read()
         assert contents == TESTDATA1.encode("utf-8")
+
+
+def test_cache_directory(localserver, clear_server, tmp_path):
+    remoteurl, localpath = localserver
+    with open(localpath + "/testfile.txt", "w") as fout:
+        fout.write(TESTDATA1)
+
+    cache_directory = tmp_path / "cache"
+    with fsspec.open(
+        "simplecache::" + remoteurl + "/testfile.txt",
+        "rb",
+        simplecache={"cache_storage": str(cache_directory)},
+    ) as f:
+        contents = f.read()
+        assert contents == TESTDATA1.encode("utf-8")
+
+    assert len(os.listdir(cache_directory)) == 1
+    with open(cache_directory / os.listdir(cache_directory)[0], "rb") as f:
+        contents = f.read()
+        assert contents == TESTDATA1.encode("utf-8")


### PR DESCRIPTION
related to https://github.com/scikit-hep/uproot5/pull/1075.

I would like to add a test in uproot where we test the `simplecache` but the files I know of are too big, would it be possible to have a small test file hosted over xrootd so we can test it? (file would need to be downloaded whole).

Edit: At the end I ended up adding an xrootd server fixture to uproot so we can test this on local files, so no need to add a new small file, but I don't think it'll hurt to add one in any case.