### PR TITLE
ci: rerun failed tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: python -m pip install .[test]
       - name: Test package
         run: |
-          python -m pytest -ra tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)OSError|timeout|expired|connection|socket"
+          python -m pytest -vv tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)OSError|timeout|expired|connection|socket"
 
       - name: Run fsspec-xrootd tests from uproot latest release
         run: |
@@ -75,7 +75,7 @@ jobs:
           python -m pip install ./uproot[test]
           # Install xrootd-fsspec again because it may have been overwritten by uproot
           python -m pip install .[test]
-          python -m pytest -ra -k "xrootd" uproot/tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)OSError|timeout|expired|connection|socket"
+          python -m pytest -vv -k "xrootd" uproot/tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)OSError|timeout|expired|connection|socket"
 
   dist:
     name: Distribution build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,8 @@ jobs:
       - name: Install package
         run: python -m pip install .[test]
       - name: Test package
-        run: python -m pytest -ra
+        run: |
+          python -m pytest -ra tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)OSError|timeout|expired|connection|socket"
 
       - name: Run fsspec-xrootd tests from uproot latest release
         run: |
@@ -74,7 +75,7 @@ jobs:
           python -m pip install ./uproot[test]
           # Install xrootd-fsspec again because it may have been overwritten by uproot
           python -m pip install .[test]
-          python -m pytest -ra -k "xrootd" uproot/tests
+          python -m pytest -ra -k "xrootd" uproot/tests --reruns 10 --reruns-delay 30 --only-rerun "(?i)OSError|timeout|expired|connection|socket"
 
   dist:
     name: Distribution build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,13 @@ build-backend = "setuptools.build_meta"
 write_to = "src/fsspec_xrootd/_version.py"
 
 
+[project.optional-dependencies]
+test = [
+    "pytest-timeout",
+    "pytest-rerunfailures",
+]
+
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
@@ -43,12 +50,12 @@ profile = "black"
 
 [tool.pylint]
 master.py-version = "3.7"
-master.ignore-paths= ["src/fsspec_xrootd/_version.py"]
+master.ignore-paths = ["src/fsspec_xrootd/_version.py"]
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"
 messages_control.disable = [
-  "design",
-  "fixme",
-  "line-too-long",
-  "wrong-import-position",
+    "design",
+    "fixme",
+    "line-too-long",
+    "wrong-import-position",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,6 @@ build-backend = "setuptools.build_meta"
 write_to = "src/fsspec_xrootd/_version.py"
 
 
-[project.optional-dependencies]
-test = [
-    "pytest-timeout",
-    "pytest-rerunfailures",
-]
-
-
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,8 @@ docs =
     sphinx-copybutton
 test =
     pytest>=6
+    pytest-rerunfailures
+    pytest-timeout
 
 [flake8]
 extend-ignore = E203, E501, E722, B950, B905


### PR DESCRIPTION
I noticed some tests now may fail due to networking issues. I also added a testing step where the uproot xrootd tests are ran (which depend on networking) so this change will significantly reduce the number of failures due to server or networking issues.