### PR TITLE
fix: drop python<3.8 requirement in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ project_urls =
 packages = find:
 install_requires =
     fsspec
-    typing-extensions>=3.7;python_version<'3.8'
 python_requires = >=3.8
 include_package_data = True
 package_dir =


### PR DESCRIPTION
Since `python_requires = >=3.8`, the `install_requires` line `typing-extensions>=3.7;python_version<'3.8'` doesn't have any effect.