### PR TITLE
Add groups for CI dependencies in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "ci: "
+    groups:
+      ci-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
Reduce number of dependabot PRs per month to 1 at most